### PR TITLE
Set CI env var

### DIFF
--- a/about.rkt
+++ b/about.rkt
@@ -162,7 +162,7 @@ VM. There@|rsquo|s no way for a package to opt out of
 testing, but a package author can implement a test suite that skip tests
 under adverse conditions. In case there@|rsquo|s no other way for a test
 suite to determine that it can@|rsquo|t run, the package-build service sets
-the @tt{PLT_PKG_BUILD_SERVICE} environment variable when running
+the @tt{PLT_PKG_BUILD_SERVICE} and @tt{CI} environment variables when running
 tests@";" a test suite can explicitly check for the environment
 variable and skip tests that can@|rsquo|t work.}
 

--- a/main.rkt
+++ b/main.rkt
@@ -332,6 +332,7 @@
                    (list (cons "PLTUSERHOME"
                                (~a (vm-dir vm) "/user"))
                          (cons "PLT_PKG_BUILD_SERVICE" "1")
+                         (cons "CI" "true")
                          (cons "PLT_INFO_ALLOW_VARS"
                                (string-append
                                 (let ([a (assoc "PLT_INFO_ALLOW_VARS" (vm-env vm))])


### PR DESCRIPTION
Numerous CI services including Travis CI, Circle CI, and Appveyor set
"CI=true" in the environment. (Typically each also sets a var specific
to them, such as "TRAVIS=true".)

It will be simpler for people to omit tests if the pkg build server
also sets this "generic" "some CI system" var.