### PR TITLE
Add dependencies to Dockerfiles

### DIFF
--- a/examples/docker/pkg-build-deps-min/Dockerfile
+++ b/examples/docker/pkg-build-deps-min/Dockerfile
@@ -1,4 +1,4 @@
 FROM ubuntu:16.04
 RUN apt-get update -y
-RUN apt-get install ca-certificates tzdata -y
+RUN apt-get install ca-certificates tzdata sqlite -y
 ENTRYPOINT ["/bin/bash"]

--- a/examples/docker/pkg-build-deps/Dockerfile
+++ b/examples/docker/pkg-build-deps/Dockerfile
@@ -2,4 +2,5 @@ FROM racket/pkg-build:pkg-build-deps-min
 RUN apt-get update -y
 RUN apt-get install gcc xvfb xterm libglib2.0-0 libpangocairo-1.0-0 -y
 RUN apt-get install libjpeg8 libpng12-0 libgtk2.0-0 libgdk-pixbuf2.0-0 libunique-1.0-0 -y
+RUN apt-get install git make -y
 ENTRYPOINT ["/bin/bash"]

--- a/examples/docker/pkg-build-deps/Dockerfile
+++ b/examples/docker/pkg-build-deps/Dockerfile
@@ -1,7 +1,5 @@
 FROM racket/pkg-build:pkg-build-deps-min
 RUN apt-get update -y
-RUN apt-get install ca-certificates tzdata -y
-RUN apt-get install gcc -y
-RUN apt-get install xvfb -y
-RUN apt-get install xterm -y
+RUN apt-get install gcc xvfb xterm libglib2.0-0 libpangocairo-1.0-0 -y
+RUN apt-get install libjpeg8 libpng12-0 libgtk2.0-0 libgdk-pixbuf2.0-0 libunique-1.0-0 -y
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
 pkg-build-deps-min:
* `sqlite` seems to be needed to build documentation

pkg-build-deps:
* `libglib2.0-0` and `libpangocairo-1.0-0` seem to be needed for racket/draw, which is used in tests and documentation
* After figuring out glib, pango, and cairo, I didn't want to go through additional builds to see exactly what else is required. The packages `libjpeg8 libpng12-0 libgtk2.0-0 libgdk-pixbuf2.0-0` are "suggested" by the `racket` package on Ubuntu 16.04, so I reasoned that they may be needed.
* It its convenient to be able to check out and build Racket from source using the same image, so I include `make` and `git`.