### PR TITLE
add VM-specific test-timeout flag

### DIFF
--- a/pkg-build.scrbl
+++ b/pkg-build.scrbl
@@ -472,7 +472,8 @@ Recognizes a @tech{VM} crreated by @racket[docker-vm] or @racket[vbox-vm].}
           [#:memory-mb memory-mb (or/c #f exact-positive-integer?) #f]
           [#:swap-mb swap-mb (or/c #f exact-positive-integer?) #f]
           [#:minimal-variant minimal-variant (or/c #f vm?) #f]
-          [#:fallback-variant fallback-variant (or/c #f vm?) #f])
+          [#:fallback-variant fallback-variant (or/c #f vm?) #f]
+          [#:test-timeout test-timeout #f (or/c #f exact-nonnegative-integer?)])
          vm?]{
 
 Creates a @tech{VM} that specifies a Docker image and container. The
@@ -523,6 +524,9 @@ succeeds with it. Only one layer of fallback is supported, currently (i.e.,
 a @racket[minimal-variant] and @racket[fallback-variant] can specified when
 creating the @racket[fallback-variant] @tech{VM}, but they are unused).}
 
+The @racket[test-timeout] argument specifies a timeout to pass to @tt{raco test}
+when it is run in this VM. 
+}
 
 @defproc[(vbox-vm
           [#:name name string?]
@@ -536,7 +540,8 @@ creating the @racket[fallback-variant] @tech{VM}, but they are unused).}
           [#:init-shapshot init-snapshot string? "init"]
           [#:installed-shapshot installed-snapshot string? "installed"]
           [#:minimal-variant minimal-variant (or/c #f vm?) #f]
-          [#:fallback-variant fallback-variant (or/c #f vm?) #f])
+          [#:fallback-variant fallback-variant (or/c #f vm?) #f]
+          [#:test-timeout test-timeout #f (or/c #f exact-nonnegative-integer?)])
          vm?]{
 
 Creates a @tech{VM} that specifies a VirtualBox virtual machine with
@@ -577,8 +582,11 @@ are used as in @racket[docker-vm].}
 
 A helper to generate a @racket[#:steps] argument to @racket[build-pkgs]
 that has steps @racket[start] through @racket[end] inclusive. See
-@racket[build-pkgs] for the allowed step symbols.}
+@racket[build-pkgs] for the allowed step symbols.
 
+The @racket[test-timeout] argument specifies a timeout to pass to @tt{raco test}
+when it is run in this VM. 
+}
 
 @defthing[main-dist-bin-pkgs (listof string?)]{
 

--- a/private/vm.rkt
+++ b/private/vm.rkt
@@ -26,7 +26,8 @@
                          #:init-shapshot string?
                          #:installed-shapshot string?
                          #:minimal-variant (or/c #f vm?)
-                         #:fallback-variant (or/c #f vm?))
+                         #:fallback-variant (or/c #f vm?)
+                         #:test-timeout [or/c #f exact-nonnegative-integer?])
                         vm?)]
           [docker-vm (->* (#:name string? #:from-image string?)
                           (#:dir (and/c string? complete-as-unix-path?)
@@ -35,6 +36,7 @@
                            #:shell (listof string?)
                            #:minimal-variant (or/c #f vm?)
                            #:fallback-variant (or/c #f vm?)
+                           #:test-timeout [or/c #f exact-nonnegative-integer?]
                            #:memory-mb (or/c #f exact-nonnegative-integer?)
                            #:swap-mb (or/c #f exact-nonnegative-integer?)
                            #:platform (or/c #f string?))
@@ -50,7 +52,7 @@
          vm-start
          vm-stop)
 
-(struct vm (name host user dir env test-env shell minimal-variant fallback-variant))
+(struct vm (name host user dir env test-env shell minimal-variant fallback-variant timeout))
 (struct vm-vbox vm (init-snapshot installed-snapshot ssh-key))
 (struct vm-docker vm (from-image memory-mb swap-mb platform))
 
@@ -93,11 +95,13 @@
          ;; If not #f, a `vm` (perhaps for a different architecture) that
          ;; will be tried if this one fails (with no recur):
          #:fallback-variant [fallback-variant #f]
+         ;; used with `raco test`, timeout in seconds
+         #:test-timeout [test-timeout #f]
          ;; Limit on "real" memory available to the container in megabytes:
          ;; Path to ssh key to use to connect to this VM:
          ;; #f indicates that ssh's defaults are used
          #:ssh-key [ssh-key #f])
-  (vm-vbox name host user dir env test-env shell minimal-variant fallback-variant
+  (vm-vbox name host user dir env test-env shell minimal-variant fallback-variant test-timeout
            init-snapshot installed-snapshot ssh-key))
 
 ;; Suggsted base Docker image names, available from Docker Hub:
@@ -130,6 +134,8 @@
          ;; If not #f, a `vm` (perhaps for a different architecture) that
          ;; will be tried if this one fails (with no recur):
          #:fallback-variant [fallback-variant #f]
+         ;; used with `raco test`, timeout in seconds
+         #:test-timeout [test-timeout #f]
          ;; Limit on "real" memory available to the container in megabytes:
          #:memory-mb [memory-mb  #f]
          ;; Amount of additional swap space available, defaults to `memory-mb`:
@@ -141,7 +147,7 @@
          ;; "racket/pkg-build:deps-x86_64" and "racket/pkg-build:deps-aarch_64" instead
          ;; of the tags without an architecture
          #:platform [platform #f])
-  (vm-docker name name "" dir env test-env shell minimal-variant fallback-variant
+  (vm-docker name name "" dir env test-env shell minimal-variant fallback-variant test-timeout
              from-image
              memory-mb swap-mb
              platform))


### PR DESCRIPTION
This is to allow the timeout when emulating x86 on an arm processor to be different than the default timeout when not emulating.